### PR TITLE
Implement real extraction methods

### DIFF
--- a/src/functions/analyzeMetrics.js
+++ b/src/functions/analyzeMetrics.js
@@ -950,7 +950,21 @@ function extractSector(content) {
 }
 
 function extractIndustry(content) {
-    // Implémentation basique
+    const industries = {
+        'IT Consulting': ['it consulting', 'technology consulting', 'digital consulting', 'systems integration'],
+        'Software Development': ['software development', 'application development', 'custom software'],
+        'Business Consulting': ['business consulting', 'strategy consulting', 'management consulting'],
+        'Outsourcing': ['outsourcing', 'managed services', 'bpo'],
+        'Cloud Services': ['cloud services', 'cloud computing', 'saas'],
+        'Data Analytics': ['data analytics', 'big data', 'business intelligence', 'data science']
+    };
+
+    const lower = content.toLowerCase();
+    for (const [industry, keywords] of Object.entries(industries)) {
+        if (keywords.some(k => lower.includes(k))) {
+            return industry;
+        }
+    }
     return null;
 }
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -189,7 +189,8 @@ function sanitizeString(input, options = {}) {
 
     // Supprimer les caractères de contrôle
     if (options.removeControlChars !== false) {
-        cleaned = cleaned.replace(/[\\x00-\\x1F\\x7F]/g, '');
+        cleaned = cleaned.replace(/[\r\n]+/g, ' ');
+        cleaned = cleaned.replace(/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/g, '');
     }
 
     // Limiter la longueur
@@ -199,7 +200,7 @@ function sanitizeString(input, options = {}) {
 
     // Supprimer les espaces multiples
     if (options.normalizeSpaces !== false) {
-        cleaned = cleaned.replace(/\\s+/g, ' ');
+        cleaned = cleaned.replace(/\s+/g, ' ');
     }
 
     return cleaned;
@@ -223,7 +224,7 @@ function formatCurrency(amount, options = {}) {
         maximumFractionDigits: options.decimals || 0
     });
 
-    return formatter.format(amount);
+    return formatter.format(amount).replace(/\u202F/g, '\u00A0');
 }
 
 /**
@@ -236,7 +237,7 @@ function formatNumber(number) {
         return '0';
     }
 
-    return new Intl.NumberFormat('fr-FR').format(number);
+    return new Intl.NumberFormat('fr-FR').format(number).replace(/\u202F/g, '\u00A0');
 }
 
 /**


### PR DESCRIPTION
## Summary
- flesh out extraction heuristics in `AnalysisService`
- improve industry extraction for metrics analysis
- fix helper utilities to sanitize strings and normalize number formats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a743c3a8832892b5e0c6c4f5cab8