### PR TITLE
Fix Jest tests for locale-aware formatting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(test).[jt]s?(x)']
+};

--- a/package.json
+++ b/package.json
@@ -5,13 +5,16 @@
   "scripts": {
     "start": "func start",
     "dev": "func start --verbose",
-    "test": "echo \"Utilisez test.http avec l'extension REST Client de VS Code\"",
+    "test": "jest",
     "deploy": "func azure functionapp publish",
     "lint": "echo \"Pas de linter configuré\""
   },
   "dependencies": {
     "@azure/functions": "^4.0.0",
     "node-fetch": "^2.7.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0"
   },
   "main": "src/{index.js,functions/*.js}",
   "engines": {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,38 @@
+const { validateInput, sanitizeString, formatCurrency, formatNumber, isValidUrl } = require('../src/utils/helpers');
+
+describe('helpers utility functions', () => {
+  test('validateInput returns valid for correct data', () => {
+    const schema = { name: { required: true, type: 'string' } };
+    const result = validateInput({ name: 'ACME' }, schema);
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('validateInput detects missing field', () => {
+    const schema = { name: { required: true, type: 'string' } };
+    const result = validateInput({}, schema);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test('sanitizeString trims and removes control chars', () => {
+    const input = '  hello\nworld\u0007';
+    const cleaned = sanitizeString(input);
+    expect(cleaned).toBe('hello world');
+  });
+
+  test('formatCurrency formats euros', () => {
+    // Narrow non-breaking spaces are used as thousand separators
+    // and a non-breaking space precedes the euro sign
+    expect(formatCurrency(1000)).toBe('1\u202F000\u00A0€');
+  });
+
+  test('formatNumber formats number with spaces', () => {
+    expect(formatNumber(1000000)).toBe('1\u202F000\u202F000');
+  });
+
+  test('isValidUrl detects valid urls', () => {
+    expect(isValidUrl('https://example.com')).toBe(true);
+    expect(isValidUrl('not_a_url')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- update tests to assert formatted numbers using unicode spaces

## Testing
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68829d9b0e288328bb1c84b3932ad4e4