### PR TITLE
Add ESLint configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "node": true,
+    "es2021": true,
+    "jest": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ company-comparables-azure-function/
    ```bash
    npm install
    ```
-2. Copy `.env.example` to `.env` or create `local.settings.json` and provide the required variables:
+2. Check code style with ESLint:
+   ```bash
+   npm run lint
+   ```
+3. Copy `.env.example` to `.env` or create `local.settings.json` and provide the required variables:
    - `SEARXNG_URL` – URL of your SearXNG instance
    - `CLIENT_ID`, `CLIENT_SECRET`, `TENANT_ID`, `TOKEN_URL` – Azure AD credentials
-3. Start the functions host:
+4. Start the functions host:
    ```bash
    npm run dev
    ```

--- a/package.json
+++ b/package.json
@@ -7,14 +7,15 @@
     "dev": "func start --verbose",
     "test": "jest",
     "deploy": "func azure functionapp publish",
-    "lint": "echo \"Pas de linter configuré\""
+    "lint": "eslint ."
   },
   "dependencies": {
     "@azure/functions": "^4.0.0",
     "node-fetch": "^2.7.0"
   },
   "devDependencies": {
-    "jest": "^29.6.0"
+    "jest": "^29.6.0",
+    "eslint": "^8.57.0"
   },
   "main": "src/{index.js,functions/*.js}",
   "engines": {


### PR DESCRIPTION
## Summary
- configure ESLint with basic recommended rules
- add lint script and eslint as dev dependency
- document lint step in README

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b33f8e5083288e88bfbd867580c5