### PR TITLE
Add startup config validation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,18 @@
+const requiredVars = ['SEARXNG_URL', 'CLIENT_ID', 'CLIENT_SECRET', 'TENANT_ID', 'TOKEN_URL'];
+
+function validateConfig() {
+    const missing = requiredVars.filter(v => !process.env[v]);
+    if (missing.length > 0) {
+        const message = `Variables d'environnement manquantes: ${missing.join(', ')}`;
+        throw new Error(message);
+    }
+    return {
+        searxngUrl: process.env.SEARXNG_URL,
+        clientId: process.env.CLIENT_ID,
+        clientSecret: process.env.CLIENT_SECRET,
+        tenantId: process.env.TENANT_ID,
+        tokenUrl: process.env.TOKEN_URL
+    };
+}
+
+module.exports = { validateConfig };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,12 @@
 const { app } = require('@azure/functions');
+const { validateConfig } = require('./config');
+
+try {
+    validateConfig();
+} catch (err) {
+    console.error(err.message);
+    process.exit(1);
+}
 
 // Import Azure Functions
 const { searchCompany } = require('./functions/searchCompany');

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,35 @@
+const { validateConfig } = require('../src/config');
+
+describe('validateConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('throws when a required variable is missing', () => {
+    delete process.env.SEARXNG_URL;
+    expect(() => validateConfig()).toThrow(/SEARXNG_URL/);
+  });
+
+  test('returns config when all variables are set', () => {
+    process.env.SEARXNG_URL = 'url';
+    process.env.CLIENT_ID = 'client';
+    process.env.CLIENT_SECRET = 'secret';
+    process.env.TENANT_ID = 'tenant';
+    process.env.TOKEN_URL = 'token';
+
+    const cfg = validateConfig();
+    expect(cfg).toEqual({
+      searxngUrl: 'url',
+      clientId: 'client',
+      clientSecret: 'secret',
+      tenantId: 'tenant',
+      tokenUrl: 'token'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- validate required environment variables at startup
- fail fast if configuration is missing
- test configuration validator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b514efec83288b992c611404094a