### PR TITLE
Add lint and test CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+
+    - run: npm ci
+    - run: npm run lint
+    - run: npm test
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `npm run lint` and `npm test` on pushes and pull requests

## Testing
- `npm run lint` *(fails: 51 errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882b713a7348328a9fb6757de3dd512