### PR TITLE
Add configurable cache timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ company-comparables-azure-function/
    npm run lint
    ```
 3. Copy `.env.example` to `.env` or create `local.settings.json` and provide the required variables:
-   - `SEARXNG_URL` – URL of your SearXNG instance
-   - `CLIENT_ID`, `CLIENT_SECRET`, `TENANT_ID`, `TOKEN_URL` – Azure AD credentials
+    - `SEARXNG_URL` – URL of your SearXNG instance
+    - `CLIENT_ID`, `CLIENT_SECRET`, `TENANT_ID`, `TOKEN_URL` – Azure AD credentials
+    - `CACHE_TIMEOUT` – cache duration for web search results in milliseconds (default 300000)
 4. Start the functions host:
    ```bash
    npm run dev

--- a/src/services/searchService.js
+++ b/src/services/searchService.js
@@ -12,7 +12,12 @@ class SearchService {
         this.tokenExpiry = null;
         
         this.cache = new Map();
-        this.cacheTimeout = 5 * 60 * 1000; // 5 minutes
+        const envTimeout = parseInt(process.env.CACHE_TIMEOUT, 10);
+        if (!isNaN(envTimeout) && envTimeout > 0) {
+            this.cacheTimeout = envTimeout;
+        } else {
+            this.cacheTimeout = 5 * 60 * 1000; // 5 minutes
+        }
         
         this.stats = {
             totalRequests: 0,


### PR DESCRIPTION
## Summary
- support CACHE_TIMEOUT environment variable in SearchService
- mention CACHE_TIMEOUT in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b758ccbc8328b45b947ec98bf124