### PR TITLE
Add CI workflow for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs Node 18, runs `npm ci`, then executes `npm run lint` and `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882bb28ef0c83288980d7eea40b8a85